### PR TITLE
fix variant tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is used to list changes made in each version of Ffuenf_Econda.
 
+## 1.0.3 (June 2, 2016)
+
+* fix proper variant tracking (only output configurables, if at least one simple is saleable; output only parent_id for configurables)
+* add logging configuration
+* remove stock_useparent as we always want to use the stock of simple products
+* fix inclusion of product types
+* add logging/exclude products without proper id
+
 ## 1.0.2 (March 17, 2016)
 
 * add variant tracking by including simple and parent product ids properly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of Ffuenf_Econda.
 * remove stock_useparent as we always want to use the stock of simple products
 * fix inclusion of product types
 * add logging/exclude products without proper id
+* add exclusion of category-ids in product feed
 
 ## 1.0.2 (March 17, 2016)
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Ffuenf_Econda
 =============
 [![GitHub tag](https://img.shields.io/github/tag/ffuenf/Ffuenf_Econda.svg)][tag]
 [![Build Status](https://img.shields.io/travis/ffuenf/Ffuenf_Econda.svg)][travis]
+[![VersionEye](https://www.versioneye.com/user/projects/5773e1a899ed29003b28122c/badge.svg)][versioneye]
 [![Code Quality](https://scrutinizer-ci.com/g/ffuenf/Ffuenf_Econda/badges/quality-score.png)][code_quality]
 [![Code Coverage](https://scrutinizer-ci.com/g/ffuenf/Ffuenf_Econda/badges/coverage.png)][code_coverage]
 [![PayPal Donate](https://img.shields.io/badge/paypal-donate-blue.svg)][paypal_donate]
 [tag]: https://github.com/ffuenf/Ffuenf_Econda
 [travis]: https://travis-ci.org/ffuenf/Ffuenf_Econda
+[versioneye]: https://www.versioneye.com/user/projects/5773e1a899ed29003b28122c
 [code_quality]: https://scrutinizer-ci.com/g/ffuenf/Ffuenf_Econda
 [code_coverage]: https://scrutinizer-ci.com/g/ffuenf/Ffuenf_Econda
 [paypal_donate]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=J2PQS2WLT2Y8W&item_name=Magento%20Extension%3a%20Ffuenf_Econda&item_number=Ffuenf_Econda&currency_code=EUR

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This extension provides more options to the official [econda Cross Sell Extensio
 * configurable product id type (ID or SKU)
 * configurable description type (short_description or description)
 * configurable product attributes (possibility to load attribute values of associated parent products)
-* exclude specific categories entirely
+* exclude products from specific categories entirely
+* exclude category ids from product feed
 
 The extension exposes the following Endpoints to fetch the generated feeds:
 

--- a/app/code/community/Ffuenf/Econda/Helper/Data.php
+++ b/app/code/community/Ffuenf/Econda/Helper/Data.php
@@ -24,6 +24,21 @@ class Ffuenf_Econda_Helper_Data extends Ffuenf_Common_Helper_Core
     const CONFIG_EXTENSION_ACTIVE = 'ffuenf_econda/general/enable';
 
     /**
+     * Path for the config for extension system log status.
+     */
+    const CONFIG_EXTENSION_LOG_SYSTEM_ACTIVE = 'ffuenf_econda/log/enable';
+
+    /**
+     * Path for the config for extension profile log status.
+     */
+    const CONFIG_EXTENSION_LOG_PROFILE_ACTIVE = 'ffuenf_econda/log/profile_enable';
+
+    /**
+     * Path for the config for extension exception log status.
+     */
+    const CONFIG_EXTENSION_LOG_EXCEPTION_ACTIVE = 'ffuenf_econda/log/exception_enable';
+
+    /**
      * Variable for if the extension is active.
      *
      * @var bool
@@ -38,5 +53,35 @@ class Ffuenf_Econda_Helper_Data extends Ffuenf_Common_Helper_Core
     public function isExtensionActive()
     {
         return $this->getStoreFlag(self::CONFIG_EXTENSION_ACTIVE, 'bExtensionActive');
+    }
+    
+    /**
+     * Check to see if logging is active.
+     *
+     * @return bool
+     */
+    public function isLogActive()
+    {
+        return Mage::getStoreConfigFlag(self::CONFIG_EXTENSION_LOG_SYSTEM_ACTIVE);
+    }
+
+    /**
+     * Check to see if profile logging is active.
+     *
+     * @return bool
+     */
+    public function isLogProfileActive()
+    {
+        return Mage::getStoreConfigFlag(self::CONFIG_EXTENSION_LOG_PROFILE_ACTIVE);
+    }
+
+    /**
+     * Check to see if exception logging is active.
+     *
+     * @return bool
+     */
+    public function isLogExceptionActive()
+    {
+        return Mage::getStoreConfigFlag(self::CONFIG_EXTENSION_LOG_EXCEPTION_ACTIVE);
     }
 }

--- a/app/code/community/Ffuenf/Econda/Model/Feeds.php
+++ b/app/code/community/Ffuenf/Econda/Model/Feeds.php
@@ -31,7 +31,6 @@ class Ffuenf_Econda_Model_Feeds
     const XML_PATH_EXTENSION_PRODUCTS_PRICE_USEPARENT       = 'ffuenf_econda/products/price_useparent';
     const XML_PATH_EXTENSION_PRODUCTS_PRICEOLD_USEPARENT    = 'ffuenf_econda/products/priceold_useparent';
     const XML_PATH_EXTENSION_PRODUCTS_NEW_USEPARENT         = 'ffuenf_econda/products/new_useparent';
-    const XML_PATH_EXTENSION_PRODUCTS_STOCK_USEPARENT       = 'ffuenf_econda/products/stock_useparent';
     const XML_PATH_EXTENSION_PRODUCTS_EAN_USEPARENT         = 'ffuenf_econda/products/ean_useparent';
     const XML_PATH_EXTENSION_PRODUCTS_BRAND_USEPARENT       = 'ffuenf_econda/products/brand_useparent';
     const XML_PATH_EXTENSION_PRODUCTS_CATEGORIES_USEPARENT  = 'ffuenf_econda/products/categories_useparent';

--- a/app/code/community/Ffuenf/Econda/Model/Feeds.php
+++ b/app/code/community/Ffuenf/Econda/Model/Feeds.php
@@ -34,7 +34,8 @@ class Ffuenf_Econda_Model_Feeds
     const XML_PATH_EXTENSION_PRODUCTS_EAN_USEPARENT         = 'ffuenf_econda/products/ean_useparent';
     const XML_PATH_EXTENSION_PRODUCTS_BRAND_USEPARENT       = 'ffuenf_econda/products/brand_useparent';
     const XML_PATH_EXTENSION_PRODUCTS_CATEGORIES_USEPARENT  = 'ffuenf_econda/products/categories_useparent';
-    const XML_PATH_EXTENSION_CATEGORIES_STATUS              = 'ffuenf_econda/categories/category_state';
+    const XML_PATH_EXTENSION_CATEGORIES_STATUS              = 'ffuenf_econda/products/category_state';
+    const XML_PATH_EXTENSION_EXCLUDED_CATEGORY_IDS          = 'ffuenf_econda/products/excluded_category_ids';
     const PRODUCTS_EXPORT_FILE                              = 'products.csv';
     const CATEGORIES_EXPORT_FILE                            = 'categories.csv';
     const STORES_EXPORT_FILE                                = 'stores.csv';

--- a/app/code/community/Ffuenf/Econda/Model/Feeds/Econda/Recommendations/Products.php
+++ b/app/code/community/Ffuenf/Econda/Model/Feeds/Econda/Recommendations/Products.php
@@ -156,10 +156,12 @@ class Ffuenf_Econda_Model_Feeds_Econda_Recommendations_Products extends Ffuenf_E
     protected function _getProductCategoriesCsv($product, $store)
     {
         $categoryIds = $product->getCategoryIds();
+        $excludedCategoryIds = explode(',', Mage::getStoreConfig(self::XML_PATH_EXTENSION_EXCLUDED_CATEGORY_IDS, $store));
         $csv = "";
         $catIds = Mage::getResourceModel('catalog/category_collection')
                   ->addAttributeToSelect(array('entity_id'))
                   ->addAttributeToFilter('entity_id', array('in' => $categoryIds))
+                  ->addAttributeToFilter('entity_id', array('nin' => $excludedCategoryIds))
                   ->addAttributeToFilter('ffuenf_econda_feed', array('eq' => 1))
                   ->setStoreId($store);
         foreach ($catIds as $catId) {

--- a/app/code/community/Ffuenf/Econda/Model/Feeds/Econda/Recommendations/Products.php
+++ b/app/code/community/Ffuenf/Econda/Model/Feeds/Econda/Recommendations/Products.php
@@ -36,10 +36,8 @@ class Ffuenf_Econda_Model_Feeds_Econda_Recommendations_Products extends Ffuenf_E
         foreach ($statuses as $status) {
             $products->addAttributeToFilter('status', array('eq' => $status));
         }
-        $types = Mage::getStoreConfig(self::XML_PATH_EXTENSION_PRODUCTS_TYPEIDS, $store);
-        foreach ($types as $type) {
-            $products->addAttributeToFilter('type_id', array('eq' => $type));
-        }
+        $types = explode(',', Mage::getStoreConfig(self::XML_PATH_EXTENSION_PRODUCTS_TYPEIDS, $store));
+        $products->addAttributeToFilter('type_id', array('in' => $types));
         $products->addAttributeToSelect(array('id', 'parent_product_ids', 'name', 'description', 'category_ids', 'manufacturer', 'image', 'price', 'news_from_date', 'news_to_date'));
         $products->addStoreFilter($storeId);
         $csv = "ID|SKU|Name|Description|ProductURL|ImageURL|Price|OldPrice|New|Stock|EAN|Brand|ProductCategory\n";
@@ -101,10 +99,30 @@ class Ffuenf_Econda_Model_Feeds_Econda_Recommendations_Products extends Ffuenf_E
                 return;
             }
         } else {
+            if ($product->getTypeId() == 'configurable') {
+                $conf = Mage::getModel('catalog/product_type_configurable')->setProduct($product);
+                $productCollection = $conf->getUsedProductCollection()->addFilterByRequiredOptions();
+                Mage::getSingleton('cataloginventory/stock')->addInStockFilterToCollection($productCollection);
+                $cnt = $productCollection->count();
+                if ($cnt == 0) {
+                    return;
+                }
+            }
             $parentProduct = $product;
         }
+        if ($this->_getProductId($parentProduct, $store) == '') {
+            Ffuenf_Common_Model_Logger::logSystem(
+                array(
+                    'class'   => 'Ffuenf_Econda',
+                    'type'    => Zend_Log::DEBUG,
+                    'message' => 'There\'s a problem with product-id ' . trim($this->_getProductId($product, $store)),
+                    'details' => 'Looks like there is no corresponding configurable product'
+                )
+            );
+            return;
+        }
         $csv = trim($this->_getProductId($parentProduct, $store)) . self::EXPORT_SEPARATOR;
-        $csv .= trim($this->_getProductId($product, $store)) . self::EXPORT_SEPARATOR;
+        $csv .= (($product->getTypeId() == 'simple') ? '"' . trim($this->_getProductId($product, $store)) . '"' : '""') . self::EXPORT_SEPARATOR;
         $csv .= '"' . trim($this->_getProductName((self::XML_PATH_EXTENSION_PRODUCTS_NAME_USEPARENT ? $parentProduct : $product))) . '"' . self::EXPORT_SEPARATOR;
         $csv .= '"' . trim($this->_getProductDescription((self::XML_PATH_EXTENSION_PRODUCTS_DESCRIPTION_USEPARENT ? $parentProduct : $product), $store)) . '"' . self::EXPORT_SEPARATOR;
         if (self::XML_PATH_EXTENSION_PRODUCTS_URL_USEPARENT) {
@@ -120,7 +138,7 @@ class Ffuenf_Econda_Model_Feeds_Econda_Recommendations_Products extends Ffuenf_E
         $csv .= trim($this->_getProductPrice((self::XML_PATH_EXTENSION_PRODUCTS_PRICE_USEPARENT ? $parentProduct : $product))) . self::EXPORT_SEPARATOR;
         $csv .= trim($this->_getProductPriceOld((self::XML_PATH_EXTENSION_PRODUCTS_PRICEOLD_USEPARENT ? $parentProduct : $product))) . self::EXPORT_SEPARATOR;
         $csv .= trim($this->_getProductNew((self::XML_PATH_EXTENSION_PRODUCTS_NEW_USEPARENT ? $parentProduct : $product))) . self::EXPORT_SEPARATOR;
-        $csv .= (int)Mage::getModel('cataloginventory/stock_item')->loadByProduct((self::XML_PATH_EXTENSION_PRODUCTS_STOCK_USEPARENT ? $parentProduct : $product))->getQty() . self::EXPORT_SEPARATOR;
+        $csv .= (int)Mage::getModel('cataloginventory/stock_item')->loadByProduct($product)->getQty() . self::EXPORT_SEPARATOR;
         if (self::XML_PATH_EXTENSION_PRODUCTS_EAN_USEPARENT) {
             $csv .= '"' . trim($parentProduct->getSku()) . '"' . self::EXPORT_SEPARATOR;
         } else {

--- a/app/code/community/Ffuenf/Econda/Test/Config/Main/expectations/testModuleConfig.yaml
+++ b/app/code/community/Ffuenf/Econda/Test/Config/Main/expectations/testModuleConfig.yaml
@@ -1,3 +1,3 @@
 module:
-  version: 1.0.2
+  version: 1.0.3
   code_pool: community

--- a/app/code/community/Ffuenf/Econda/etc/config.xml
+++ b/app/code/community/Ffuenf/Econda/etc/config.xml
@@ -20,7 +20,7 @@
 <config>
     <modules>
         <Ffuenf_Econda>
-            <version>1.0.2</version>
+            <version>1.0.3</version>
         </Ffuenf_Econda>
     </modules>
     <global>

--- a/app/code/community/Ffuenf/Econda/etc/system.xml
+++ b/app/code/community/Ffuenf/Econda/etc/system.xml
@@ -134,12 +134,21 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </category_state>
+                        <excluded_category_ids translate="label, comment">
+                            <label>Excluded Category IDs (comma separated)</label>
+                            <comment><![CDATA[Exclude these category ids from the products feed.]]></comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>51</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </excluded_category_ids>
                         <name_useparent translate="label, comment">
                             <label><![CDATA[Use <b>Name</b> of parent product]]></label>
                             <comment><![CDATA[Useful if your simple products generally inherit data from its configurable product.]]></comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>50</sort_order>
+                            <sort_order>52</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>

--- a/app/code/community/Ffuenf/Econda/etc/system.xml
+++ b/app/code/community/Ffuenf/Econda/etc/system.xml
@@ -204,16 +204,6 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </new_useparent>
-                        <stock_useparent translate="label, comment">
-                            <label><![CDATA[Use <b>Stock</b> of parent product]]></label>
-                            <comment><![CDATA[Useful if your simple products generally inherit data from its configurable product.]]></comment>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>120</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>
-                        </stock_useparent>
                         <ean_useparent translate="label, comment">
                             <label><![CDATA[Use <b>EAN</b> of parent product]]></label>
                             <comment><![CDATA[Useful if your simple products generally inherit data from its configurable product.]]></comment>
@@ -246,6 +236,44 @@
                         </categories_useparent>
                     </fields>
                 </products>
+                <log translate="label, comment" module="ffuenf_common">
+                    <label>Logging Configuration</label>
+                    <comment><![CDATA[Enable the logging functions for debugging purposes only]]></comment>
+                    <sort_order>3000</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>0</show_in_website>
+                    <show_in_store>0</show_in_store>
+                    <expanded>0</expanded>
+                    <fields>
+                        <enable translate="label, comment" module="ffuenf_common">
+                            <label>Enable system logging</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>1</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </enable>
+                        <profile_enable translate="label, comment" module="ffuenf_common">
+                            <label>Enable profile logging</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>7</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </profile_enable>
+                        <exception_enable translate="label, comment" module="ffuenf_common">
+                            <label>Enable exception logging</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>8</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </exception_enable>
+                    </fields>
+                </log>
             </groups>
         </ffuenf_econda>
     </sections>

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     {
       "type": "composer",
-      "url": "https://packages.magento.com"
+      "url": "https://repo.magento.com"
     },
     {
       "type": "vcs",

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,6 @@
       "url": "https://packages.firegento.com"
     },
     {
-      "type": "composer",
-      "url": "https://repo.magento.com"
-    },
-    {
       "type": "vcs",
       "url": "https://github.com/ffuenf/Ffuenf_Common"
     },


### PR DESCRIPTION
* fix proper variant tracking (only output configurables, if at least one simple is saleable; output only parent_id for configurables)
* add logging configuration
* remove stock_useparent as we always want to use the stock of simple products
* fix inclusion of product types
* add logging/exclude products without proper id